### PR TITLE
Add --pretty=medium as default option on changelog

### DIFF
--- a/lib/step-up/driver/git.rb
+++ b/lib/step-up/driver/git.rb
@@ -93,7 +93,7 @@ check with the following bash command:
       end
 
       def version_tag_info(tag)
-        full_message = `git show #{ tag } --no-decorate --quiet --date=default`
+        full_message = `git show #{ tag } --pretty=medium --no-decorate --quiet --date=default`
         tag_pattern = tag.gsub(/\./, '\\.')
         tag_message = full_message[/^tag\s#{tag_pattern}.*?\n\n(.*?)\n\n(?:tag\s[^\s]+|commit\s\w{40})\n/m, 1] || ""
         tagger = full_message[/\A.*?\nTagger:\s(.*?)\s</m, 1]


### PR DESCRIPTION
When the user has a customized `.gitconfig` with pretty option, like:
`~/.gitconfig`

```
[format]
  pretty = format:%C(blue)%ad%Creset %C(yellow)%h%C(green)%d%Creset %C(blue)%s %C(magenta) [%an]%Creset
```

and runs `stepup changelog`, it will raise an error:

```
StepUp Exception: no implicit conversion of nil into String
```

This errors occurs because with this format, the "Date" label doesn't show on `git show`.

`git show 1.0.1 --no-decorate --quiet --date=default`

```
tag 1.0.1
Tagger: xxxxx

Other changes:

  - Using costelinha/bacon as continuous integration

Thu Apr 16 17:09:36 2015 -0300 afd49ca (tag: 1.0.1) Updating version  xxxxxxx
```

With this change, the method will force the `--pretty=medium`, resulting on the expected result:
`git show 1.0.1 --pretty=medium --no-decorate --quiet --date=default`

```
tag 1.0.1
Tagger: xxxxx
Date:   Thu Apr 16 17:18:06 2015 -0300

Other changes:

  - Using costelinha/bacon as continuous integration

commit afd49caf9dd97490a531112cb1196e8716bca6cd
Author: xxxx
Date:   Thu Apr 16 17:09:36 2015 -0300

    Updating version
```
